### PR TITLE
Fix package comment package name

### DIFF
--- a/jsonlog.go
+++ b/jsonlog.go
@@ -1,4 +1,4 @@
-// Package logs provides structured JSON logging with arbitrary data. It
+// Package jsonlog provides structured JSON logging with arbitrary data. It
 // supports contexts and can extract values from these.
 package jsonlog
 


### PR DESCRIPTION
Most likely, "logs" was an old name; I've corrected it here since the
form of the package comment should be "Package [package-name] ..."